### PR TITLE
fix: don't enable empty security definitions if no oidc list is specified

### DIFF
--- a/api.js
+++ b/api.js
@@ -15,16 +15,16 @@ module.exports = documents => `
                 <div class="api">${Object.entries(documents).map(([namespace, {host, info: {title, description, version} = {}}]) => `
                     <div>
                         <div class="namespace">
-                            <div class="title"/>${title}</div>
+                            <div class="title">${title}</div>
                             <div class="tags">
-                                <div class="version"/>${version}</div>
+                                <div class="version">${version}</div>
                             </div>
-                            <div class="description"/>${description}</div>
+                            <div class="description">${description}</div>
                             <hr />
                             <div class="description">API links</div>
-                            <div class="link"/><a href="${prefix(host, namespace)}swagger.json">Swagger</a></div>
-                            <div class="link"/><a href="${prefix(host, namespace)}swagger.html">Swagger UI</a></div>
-                            <div class="link"/><a href="${prefix(host, namespace)}redoc.html">Redoc</a></div>
+                            <div class="link"><a href="${prefix(host, namespace)}swagger.json">Swagger</a></div>
+                            <div class="link"><a href="${prefix(host, namespace)}swagger.html">Swagger UI</a></div>
+                            <div class="link"><a href="${prefix(host, namespace)}redoc.html">Redoc</a></div>
                         </div>
                     </div>`).join('\r\n')}
                 </div>

--- a/index.js
+++ b/index.js
@@ -15,18 +15,20 @@ const emptyDoc = (oidc, namespace = 'custom', version = '0.0.1') => ({
         description: 'Internal microservice API',
         version
     },
-    security: oidc.map(({issuer}) => ({[issuer]: ['email']})),
-    securityDefinitions: oidc.reduce((prev, cur) => ({
-        ...prev,
-        [cur.issuer]: {
-            type: 'oauth2',
-            flow: 'accessCode',
-            authorizationUrl: cur.authorization_endpoint,
-            tokenUrl: cur.token_endpoint,
-            'x-tokenName': 'id_token',
-            scopes: {email: 'email'}
-        }
-    }), {}),
+    ...oidc.length && {
+        security: oidc.map(({issuer}) => ({[issuer]: ['email']})),
+        securityDefinitions: oidc.reduce((prev, cur) => ({
+            ...prev,
+            [cur.issuer]: {
+                type: 'oauth2',
+                flow: 'accessCode',
+                authorizationUrl: cur.authorization_endpoint,
+                tokenUrl: cur.token_endpoint,
+                'x-tokenName': 'id_token',
+                scopes: {email: 'email'}
+            }
+        }), {})
+    },
     paths: {}
 });
 

--- a/swagger.js
+++ b/swagger.js
@@ -102,7 +102,7 @@ module.exports = oauth => `<!DOCTYPE html>
                 oauth2RedirectUrl: document.location.origin + '/oauth2-redirect.html',
                 validatorUrl: null
             })
-            ${oauth && `ui.initOAuth(${JSON.stringify(oauth)})`}
+            ${oauth ? `ui.initOAuth(${JSON.stringify(oauth)})` : ''}
             window.ui = ui
         }
 


### PR DESCRIPTION
fixes included:
* don't enable empty security definitions if no oidc list is specified
* fix API Docs html syntax
* don't print `undefined` in swagger ui script