### PR TITLE
fix: usePkceWithAuthorizationCodeGrant: true and clientId: 'web' by default

### DIFF
--- a/swagger.js
+++ b/swagger.js
@@ -1,6 +1,5 @@
 module.exports = (oauth, {service}, {url = './document.json'}) => {
     const basePath = service ? '..' : '.';
-    const oauthParams = oauth && {usePkceWithAuthorizationCodeGrant: true, clientId: 'web', ...oauth};
     return `<!DOCTYPE html>
     <html lang="en">
 
@@ -105,7 +104,7 @@ module.exports = (oauth, {service}, {url = './document.json'}) => {
                     oauth2RedirectUrl: document.location.origin + '/oauth2-redirect.html',
                     validatorUrl: null
                 })
-                ${oauthParams ? `ui.initOAuth(${JSON.stringify(oauthParams)})` : ''}
+                ui.initOAuth(${JSON.stringify({usePkceWithAuthorizationCodeGrant: true, clientId: 'web', ...oauth})})
                 window.ui = ui
             }
 

--- a/tap-snapshots/test/apiDoc.test.js.test.cjs
+++ b/tap-snapshots/test/apiDoc.test.js.test.cjs
@@ -210,7 +210,7 @@ exports[`test/apiDoc.test.js TAP rpcRoutes > custom swagger UI html 1`] = `
                     oauth2RedirectUrl: document.location.origin + '/oauth2-redirect.html',
                     validatorUrl: null
                 })
-                
+                ui.initOAuth({"usePkceWithAuthorizationCodeGrant":true,"clientId":"web"})
                 window.ui = ui
             }
 


### PR DESCRIPTION
set usePkceWithAuthorizationCodeGrant: true and clientId: 'web' by default for swagger oauth